### PR TITLE
Added Goji (https://goji.io) + nosurf example.

### DIFF
--- a/examples/goji.go
+++ b/examples/goji.go
@@ -1,0 +1,69 @@
+// Demonstrates how to tie together Goji (https://goji.io) and nosurf.
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/zenazn/goji"
+	"github.com/zenazn/goji/web"
+
+	"github.com/justinas/nosurf"
+)
+
+var templateString = `
+<!doctype html>
+<html>
+<body>
+{{ if .name }}
+<p>Your name: {{ .name }}</p>
+{{ end }}
+<form action="/signup/submit" method="POST">
+<input type="text" name="name">
+
+<!-- Try removing this or changing its value 
+     and see what happens -->
+<input type="hidden" name="csrf_token" value="{{ .csrf_token }}">
+<input type="submit" value="Send">
+</form>
+</body>
+</html>
+`
+
+var templ = template.Must(template.New("t1").Parse(templateString))
+
+type M map[string]interface{}
+
+func IndexHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Our index page")
+}
+
+func ShowSignupForm(c web.C, w http.ResponseWriter, r *http.Request) {
+	templ.Execute(w, M{
+		"csrf_token": nosurf.Token(r), // Pass the CSRF token to the template
+	})
+}
+
+func SubmitSignupForm(c web.C, w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintf(w, "Successfully submitted, %s!", r.FormValue("name"))
+}
+
+func main() {
+	goji.Get("/", IndexHandler) // Doesn't need CSRF protection (no POST/PUT/DELETE actions).
+
+	signup := web.New()
+	goji.Handle("/signup/*", signup)
+	// But our signup forms do, so we add nosurf to their middleware stack (only).
+	signup.Use(nosurf.NewPure)
+	signup.Get("/signup/new", ShowSignupForm)
+	signup.Post("/signup/submit", SubmitSignupForm)
+
+	goji.Serve()
+}


### PR DESCRIPTION
As the title says. I've kept it fairly minimal whilst still showing how you can add `nosurf` to sub-routers (only) — i.e. your forms and not your busy landing page.
