### PR TITLE
Changed default expiry to 1 day (from 365 days).

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -19,8 +19,8 @@ const (
 	// the HTTP status code for the default failure handler
 	FailureCode = 400
 
-	// Max-Age in seconds for the default base cookie. 365 days.
-	MaxAge = 365 * 24 * 60 * 60
+	// Max-Age in seconds for the default base cookie. 1 day.
+	MaxAge = 1 * 24 * 60 * 60
 )
 
 var safeMethods = []string{"GET", "HEAD", "OPTIONS", "TRACE"}


### PR DESCRIPTION
This should not negatively affect user experience, as users are _extremely_ unlikely to make a GET request, and then a subsequent POST request > 1 day later (without making another GET request first).

I'd be happy to bump this up to 7 or 14 days if you have a strong preference for it. 
