### PR TITLE
Make reads of random bytes panic on error.

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -33,7 +33,9 @@ func maskToken(data []byte) []byte {
 	copy(token, data)
 
 	// generate the random token
-	io.ReadFull(rand.Reader, key)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		panic(err)
+	}
 
 	oneTimePad(token, key)
 	return result

--- a/token.go
+++ b/token.go
@@ -33,14 +33,10 @@ and then treated as 32/64 byte slices.
 // from crypto/rand
 func generateToken() []byte {
 	bytes := make([]byte, tokenLength)
-	_, _ = io.ReadFull(rand.Reader, bytes)
 
-	// I'm not sure how to handle the error from the above call.
-	// It shouldn't EVER really happen,
-	// as we check for the availablity of crypto/random
-	// in the init() function
-	// and both /dev/urandom and CryptGenRandom()
-	// should be inexhaustible.
+	if _, err := io.ReadFull(rand.Reader, bytes); err != nil {
+		panic(err)
+	}
 
 	return bytes
 }


### PR DESCRIPTION
Since we check for availability of random reader on startup, errors on
rand.Reader probably won't happen, however panicking in case of error is
still better than providing non-random values as if nothing happened.