### PR TITLE
Expose VerifyToken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nosurf
 
 [![Build Status](https://travis-ci.org/justinas/nosurf.svg?branch=master)](https://travis-ci.org/justinas/nosurf)
+[![GoDoc](http://godoc.org/github.com/justinas/nosurf?status.png)](http://godoc.org/github.com/justinas/nosurf)
 
 `nosurf` is an HTTP package for Go
 that helps you prevent Cross-Site Request Forgery attacks.
@@ -30,6 +31,43 @@ Want to present the hacker with an ASCII middle finger
 instead of the plain old `HTTP 400`? No problem.
 * Uses masked tokens to mitigate the BREACH attack
 * Has no dependencies outside the Go standard library.
+
+### Manual token verification
+In some cases the CSRF token may be send through a non standard way,
+e.g. a body or request is a JSON encoded message with one of the fields
+being a token.
+
+In such case the handler(path) should be excluded from an automatic
+verification by using one of the exemption methods:
+
+```go
+	func (h *CSRFHandler) ExemptFunc(fn func(r *http.Request) bool)
+	func (h *CSRFHandler) ExemptGlob(pattern string)
+	func (h *CSRFHandler) ExemptGlobs(patterns ...string)
+	func (h *CSRFHandler) ExemptPath(path string)
+	func (h *CSRFHandler) ExemptPaths(paths ...string)
+	func (h *CSRFHandler) ExemptRegexp(re interface{})
+	func (h *CSRFHandler) ExemptRegexps(res ...interface{})
+```
+
+Later on, the token **must** be verify by manually getting a token from cookie
+and providing the token sent in body through: `VerifyToken(tkn, tkn2 string) bool`.
+
+Example:
+```go
+func HandleJson(w http.ResponseWriter, r *http.Request) {
+	d := struct{
+		X,Y int
+		Tkn string
+	}{}
+	json.Unmarshal(ioutil.ReadALl(r.Body), &d)
+	if !nosurf.VerifyToken(Token(r), d.Tkn) {
+		http.Errorf(w, "CSRF token wrong or incorrect", http.StatusBadRequest)
+		return
+	}
+	// do smth cool
+}
+```
 
 ### Example
 ```go

--- a/handler.go
+++ b/handler.go
@@ -132,13 +132,8 @@ func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctxSetToken(r, realToken)
 	}
 
-	if sContains(safeMethods, r.Method) {
+	if sContains(safeMethods, r.Method) || h.IsExempt(r) {
 		// short-circuit with a success for safe methods
-		h.handleSuccess(w, r)
-		return
-	}
-
-	if h.IsExempt(r) {
 		h.handleSuccess(w, r)
 		return
 	}
@@ -168,8 +163,7 @@ func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Finally, we check the token itself.
 	sentToken := extractToken(r)
 
-	equals := VerifyToken(realToken, sentToken)
-	if !equals {
+	if !verifyToken(realToken, sentToken) {
 		ctxSetReason(r, ErrBadToken)
 		h.handleFailure(w, r)
 		return

--- a/handler.go
+++ b/handler.go
@@ -168,7 +168,7 @@ func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Finally, we check the token itself.
 	sentToken := extractToken(r)
 
-	equals := verifyToken(realToken, sentToken)
+	equals := VerifyToken(realToken, sentToken)
 	if !equals {
 		ctxSetReason(r, ErrBadToken)
 		h.handleFailure(w, r)

--- a/token.go
+++ b/token.go
@@ -53,10 +53,10 @@ func b64decode(data string) []byte {
 	return decoded
 }
 
-// Verifies the sent token equals the real one
+// VerifyToken verifies the sent token equals the real one
 // and returns a bool value indicating if tokens are equal.
 // Supports masked tokens.
-func verifyToken(realToken, sentToken []byte) bool {
+func VerifyToken(realToken, sentToken []byte) bool {
 	realN := len(realToken)
 	sentN := len(sentToken)
 

--- a/token.go
+++ b/token.go
@@ -55,8 +55,21 @@ func b64decode(data string) []byte {
 
 // VerifyToken verifies the sent token equals the real one
 // and returns a bool value indicating if tokens are equal.
-// Supports masked tokens.
-func VerifyToken(realToken, sentToken []byte) bool {
+// Supports masked tokens. realToken comes from Token(r) and
+// sentToken is token sent unusual way.
+func VerifyToken(realToken, sentToken string) bool {
+	r := b64decode(realToken)
+	if len(r) == 2*tokenLength {
+		r = unmaskToken(r)
+	}
+	s := b64decode(sentToken)
+	if len(s) == 2*tokenLength {
+		s = unmaskToken(s)
+	}
+	return subtle.ConstantTimeCompare(r, s) == 1
+}
+
+func verifyToken(realToken, sentToken []byte) bool {
 	realN := len(realToken)
 	sentN := len(sentToken)
 

--- a/token_test.go
+++ b/token_test.go
@@ -41,16 +41,16 @@ func TestGeneratesAValidToken(t *testing.T) {
 func TestVerifyTokenChecksLengthCorrectly(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		slice := make([]byte, i)
-		result := verifyToken(slice, slice)
+		result := VerifyToken(slice, slice)
 		if result != false {
-			t.Errorf("verifyToken should've returned false with slices of length %d", i)
+			t.Errorf("VerifyToken should've returned false with slices of length %d", i)
 		}
 	}
 
 	slice := make([]byte, 64)
-	result := verifyToken(slice[:32], slice)
+	result := VerifyToken(slice[:32], slice)
 	if result != true {
-		t.Errorf("verifyToken should've returned true on a zeroed slice of length 64")
+		t.Errorf("VerifyToken should've returned true on a zeroed slice of length 64")
 	}
 }
 
@@ -60,13 +60,13 @@ func TestVerifiesMaskedTokenCorrectly(t *testing.T) {
 		"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
 		"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 
-	if !verifyToken(realToken, sentToken) {
-		t.Errorf("verifyToken returned a false negative")
+	if !VerifyToken(realToken, sentToken) {
+		t.Errorf("VerifyToken returned a false negative")
 	}
 
 	realToken[0] = 'x'
 
-	if verifyToken(realToken, sentToken) {
-		t.Errorf("verifyToken returned a false positive")
+	if VerifyToken(realToken, sentToken) {
+		t.Errorf("VerifyToken returned a false positive")
 	}
 }

--- a/token_test.go
+++ b/token_test.go
@@ -41,14 +41,14 @@ func TestGeneratesAValidToken(t *testing.T) {
 func TestVerifyTokenChecksLengthCorrectly(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		slice := make([]byte, i)
-		result := VerifyToken(slice, slice)
+		result := verifyToken(slice, slice)
 		if result != false {
 			t.Errorf("VerifyToken should've returned false with slices of length %d", i)
 		}
 	}
 
 	slice := make([]byte, 64)
-	result := VerifyToken(slice[:32], slice)
+	result := verifyToken(slice[:32], slice)
 	if result != true {
 		t.Errorf("VerifyToken should've returned true on a zeroed slice of length 64")
 	}
@@ -60,13 +60,13 @@ func TestVerifiesMaskedTokenCorrectly(t *testing.T) {
 		"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
 		"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 
-	if !VerifyToken(realToken, sentToken) {
+	if !verifyToken(realToken, sentToken) {
 		t.Errorf("VerifyToken returned a false negative")
 	}
 
 	realToken[0] = 'x'
 
-	if VerifyToken(realToken, sentToken) {
+	if verifyToken(realToken, sentToken) {
 		t.Errorf("VerifyToken returned a false positive")
 	}
 }


### PR DESCRIPTION
Allows to verify a token coming from non-standard source e.g. JSON encoded body.