### PR TITLE
Allow setting the name of the CSRF cookie

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -105,6 +105,14 @@ func NewPure(handler http.Handler) http.Handler {
 	return New(handler)
 }
 
+func (h CSRFHandler) getCookieName() string {
+	if h.baseCookie.Name != "" {
+		return h.baseCookie.Name
+	}
+
+	return CookieName
+}
+
 func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = addNosurfContext(r)
 	defer ctxClear(r)
@@ -112,7 +120,7 @@ func (h *CSRFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var realToken []byte
 
-	tokenCookie, err := r.Cookie(CookieName)
+	tokenCookie, err := r.Cookie(h.getCookieName())
 	if err == nil {
 		realToken = b64decode(tokenCookie.Value)
 	}
@@ -198,7 +206,7 @@ func (h *CSRFHandler) setTokenCookie(w http.ResponseWriter, r *http.Request, tok
 	ctxSetToken(r, token)
 
 	cookie := h.baseCookie
-	cookie.Name = CookieName
+	cookie.Name = h.getCookieName()
 	cookie.Value = b64encode(token)
 
 	http.SetCookie(w, &cookie)

--- a/handler_test.go
+++ b/handler_test.go
@@ -252,6 +252,29 @@ func TestWrongTokenFails(t *testing.T) {
 	}
 }
 
+func TestCustomCookieName(t *testing.T) {
+	hand := New(http.HandlerFunc(succHand))
+
+	if hand.getCookieName() != CookieName {
+		t.Errorf("No base cookie set, expected CookieName to be %s, was %s", CookieName, hand.getCookieName())
+	}
+
+	hand.SetBaseCookie(http.Cookie{})
+
+	if hand.getCookieName() != CookieName {
+		t.Errorf("Base cookie with empty name set, expected CookieName to be %s, was %s", CookieName, hand.getCookieName())
+	}
+
+	customCookieName := "my_custom_cookie"
+	hand.SetBaseCookie(http.Cookie{
+		Name: customCookieName,
+	})
+
+	if hand.getCookieName() != customCookieName {
+		t.Errorf("Base cookie with name %s was set, but CookieName was %s instead", customCookieName, hand.getCookieName())
+	}
+}
+
 // For this and similar tests we start a test server
 // Since it's much easier to get the cookie
 // from a normal http.Response than from the recorder


### PR DESCRIPTION
I required changing the name of the cookie, but as far as I could tell the library doesn't currently allow for that.