### PR TITLE
Return empty string if token does not exist in request context

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,7 +27,10 @@ type csrfContext struct {
 // (that is, in another handler that wraps it,
 // or after the request has been served)
 func Token(req *http.Request) string {
-	ctx := req.Context().Value(nosurfKey).(*csrfContext)
+	ctx, ok := req.Context().Value(nosurfKey).(*csrfContext)
+	if !ok {
+		return ""
+	}
 
 	return ctx.token
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,14 @@
+package nosurf
+
+import (
+	"testing"
+)
+
+func TestTokenForRequestWithoutContext(t *testing.T) {
+	req := dummyGet()
+	token := Token(req)
+
+	if token != "" {
+		t.Errorf("Token should be %q but it's %v", "", token)
+	}
+}


### PR DESCRIPTION
Fixes issue https://github.com/justinas/nosurf/issues/39.

Feel free to close if you want to take an alternative approach to the problem.