### PR TITLE
Resolve critical vulnerability allowing arbitrary tokens to pass as matching

### DIFF
--- a/token.go
+++ b/token.go
@@ -72,9 +72,10 @@ func VerifyToken(realToken, sentToken string) bool {
 	if len(s) == 2*tokenLength {
 		s = unmaskToken(s)
 	}
-	return subtle.ConstantTimeCompare(r, s) == 1 && len(r) > 0 && len(s) > 0
+	return tokensEqual(r, s)
 }
 
+// verifyToken expects the realToken to be unmasked and the sentToken to be masked
 func verifyToken(realToken, sentToken []byte) bool {
 	realN := len(realToken)
 	sentN := len(sentToken)
@@ -83,15 +84,16 @@ func verifyToken(realToken, sentToken []byte) bool {
 	// sentN == 2*tokenLength means the token is masked.
 
 	if realN == tokenLength && sentN == 2*tokenLength {
-		return verifyMasked(realToken, sentToken)
+		return tokensEqual(realToken, unmaskToken(sentToken))
 	}
 	return false
 }
 
-// Verifies the masked token
-func verifyMasked(realToken, sentToken []byte) bool {
-	sentPlain := unmaskToken(sentToken)
-	return subtle.ConstantTimeCompare(realToken, sentPlain) == 1
+// tokensEqual expects both tokens to be unmasked
+func tokensEqual(realToken, sentToken []byte) bool {
+	return len(realToken) == tokenLength &&
+		len(sentToken) == tokenLength &&
+		subtle.ConstantTimeCompare(realToken, sentToken) == 1
 }
 
 func checkForPRNG() {

--- a/token.go
+++ b/token.go
@@ -58,15 +58,21 @@ func b64decode(data string) []byte {
 // Supports masked tokens. realToken comes from Token(r) and
 // sentToken is token sent unusual way.
 func VerifyToken(realToken, sentToken string) bool {
-	r := b64decode(realToken)
+	r, err := base64.StdEncoding.DecodeString(realToken)
+	if err != nil {
+		return false
+	}
 	if len(r) == 2*tokenLength {
 		r = unmaskToken(r)
 	}
-	s := b64decode(sentToken)
+	s, err := base64.StdEncoding.DecodeString(sentToken)
+	if err != nil {
+		return false
+	}
 	if len(s) == 2*tokenLength {
 		s = unmaskToken(s)
 	}
-	return subtle.ConstantTimeCompare(r, s) == 1
+	return subtle.ConstantTimeCompare(r, s) == 1 && len(r) > 0 && len(s) > 0
 }
 
 func verifyToken(realToken, sentToken []byte) bool {

--- a/token_test.go
+++ b/token_test.go
@@ -70,3 +70,16 @@ func TestVerifiesMaskedTokenCorrectly(t *testing.T) {
 		t.Errorf("VerifyToken returned a false positive")
 	}
 }
+
+func TestVerifyTokenBase64Invalid(t *testing.T) {
+	for _, pairs := range [][]string{
+		{"foo", "bar"},
+		{"foo", ""},
+		{"", "bar"},
+		{"", ""},
+	} {
+		if VerifyToken(pairs[0], pairs[1]) {
+			t.Errorf("VerifyToken returned a false positive for: %v", pairs)
+		}
+	}
+}


### PR DESCRIPTION
Before applying the patch to `token.go`, `VerifyToken` would incorrectly allow the following pairs to appear as equal:

```
    token_test.go:82: VerifyToken returned a false positive for: [foo bar]
    token_test.go:82: VerifyToken returned a false positive for: [foo ]
    token_test.go:82: VerifyToken returned a false positive for: [ bar]
    token_test.go:82: VerifyToken returned a false positive for: [ ]
```

This opens up attack vectors when developers rely on `VerifyToken` in cases where the attacker could trick the first parameter (`realToken`) into being an arbitrary value. Given that `VerifyToken` does not rely on `r *http.Request` to extract the token, this could happen when misusing the API or when other exploits are found to the way `nosurf.Token(r)` works.

This patch handles empty values and base64 decoding errors as verification failures and allows the failing test cases to pass.