### PR TITLE
Add failing test case for double cookie setting

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -9,6 +9,22 @@ import (
 	"testing"
 )
 
+func TestNoDoubleCookie(t *testing.T) {
+	var n *CSRFHandler
+	n = New(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.RegenerateToken(w, r)
+	}))
+
+	r := httptest.NewRequest("GET", "http://dummy.us", nil)
+	w := httptest.NewRecorder()
+
+	n.ServeHTTP(w, r)
+
+	if len(w.Result().Cookies()) > 1 {
+		t.Errorf("Expected one CSRF cookie, got %d", len(w.Result().Cookies()))
+	}
+}
+
 func TestDefaultFailureHandler(t *testing.T) {
 	writer := httptest.NewRecorder()
 	req := dummyGet()


### PR DESCRIPTION
The problem is that `ServeHTTP` detects that the cookie is missing. So it calls `RegenerateToken()` to create a new token. Because the downstream handler doesn't know that (and really has no way of currently knowing), it also calls `RegenerateToken()`. This then adds a second cookie to the HTTP response, causing this behavior.

See #61